### PR TITLE
Fix bundling order

### DIFF
--- a/codeql_bundle/cli.py
+++ b/codeql_bundle/cli.py
@@ -80,24 +80,24 @@ def main(
     try:
         bundle = CustomBundle(bundle_path, workspace)
         logger.info(f"Looking for CodeQL packs in workspace {workspace}")
-        packs_in_workspace = bundle.codeql.pack_ls(workspace)
+        packs_in_workspace = bundle.getCodeQLPacks()
         logger.info(
-            f"Found the CodeQL packs: {','.join(map(lambda p: p.name, packs_in_workspace))}"
+            f"Found the CodeQL packs: {','.join(map(lambda p: p.config.name, packs_in_workspace))}"
         )
 
         if len(packs) > 0:
             selected_packs = [
                 available_pack
                 for available_pack in packs_in_workspace
-                if available_pack.name in packs
+                if available_pack.config.name in packs
             ]
         else:
             selected_packs = packs_in_workspace
 
         logger.info(
-            f"Considering the following CodeQL packs for inclusion in the custom bundle: {','.join(map(lambda p: p.name, selected_packs))}"
+            f"Considering the following CodeQL packs for inclusion in the custom bundle: {','.join(map(lambda p: p.config.name, selected_packs))}"
         )
-        missing_packs = set(packs) - {pack.name for pack in selected_packs}
+        missing_packs = set(packs) - {pack.config.name for pack in selected_packs}
         if len(missing_packs) > 0:
             logger.fatal(
                 f"The provided CodeQL workspace doesn't contain the provided packs '{','.join(missing_packs)}'",
@@ -105,7 +105,7 @@ def main(
             sys.exit(1)
 
         logger.info(
-            f"Adding the packs {','.join(map(lambda p: p.name, selected_packs))} to the custom bundle."
+            f"Adding the packs {','.join(map(lambda p: p.config.name, selected_packs))} and its workspace dependencies to the custom bundle."
         )
         bundle.add_packs(*selected_packs)
         logger.info(f"Bundling custom bundle at {output}")

--- a/codeql_bundle/cli.py
+++ b/codeql_bundle/cli.py
@@ -1,3 +1,12 @@
+# Add the parent directory to the path if this module is run directly (i.e. not imported)
+# This is necessary to support both the Poetry script invocation and the direct invocation.
+if not __package__ and __name__ == "__main__":
+    import sys
+    from pathlib import Path
+
+    sys.path.append(str(Path(__file__).parent.parent))
+    __package__ = Path(__file__).parent.name
+
 import click
 from pathlib import Path
 from codeql_bundle.helpers.codeql import CodeQLException

--- a/codeql_bundle/cli.py
+++ b/codeql_bundle/cli.py
@@ -17,7 +17,6 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-
 @click.command()
 @click.option(
     "-b",

--- a/codeql_bundle/helpers/bundle.py
+++ b/codeql_bundle/helpers/bundle.py
@@ -207,13 +207,13 @@ class CustomBundle(Bundle):
         for pack in [p for p in self.workspace_packs if p.kind == CodeQLPackKind.CUSTOMIZATION_PACK]:
             del pack.dependencies[0]
 
-        def is_dependend_on(pack: ResolvedCodeQLPack, other: ResolvedCodeQLPack) -> bool:
-            return other in pack.dependencies or any(map(lambda p: is_dependend_on(p, other), pack.dependencies))
+        def is_dependent_on(pack: ResolvedCodeQLPack, other: ResolvedCodeQLPack) -> bool:
+            return other in pack.dependencies or any(map(lambda p: is_dependent_on(p, other), pack.dependencies))
         # Add the stdlib and its dependencies to properly sort the customization packs before the other packs.
         for pack, deps in std_lib_deps.items():
             pack_sorter.add(pack, *deps)
             # Add the standard query packs that rely transitively on the stdlib.
-            for query_pack in [p for p in self.bundle_packs if p.kind == CodeQLPackKind.QUERY_PACK and is_dependend_on(p, pack)]:
+            for query_pack in [p for p in self.bundle_packs if p.kind == CodeQLPackKind.QUERY_PACK and is_dependent_on(p, pack)]:
                 pack_sorter.add(query_pack, pack)
 
         def bundle_customization_pack(customization_pack: ResolvedCodeQLPack):

--- a/codeql_bundle/helpers/codeql.py
+++ b/codeql_bundle/helpers/codeql.py
@@ -150,7 +150,7 @@ class CodeQL:
         if pack.config.library:
             raise CodeQLException(f"Cannot bundle non-query pack {pack.config.name}!")
 
-        args = ["create", "--format=json", f"--output={output_path}", "--threads=0"]
+        args = ["create", "--format=json", f"--output={output_path}", "--threads=0", "--no-default-compilation-cache"]
         if self.supports_qlx():
             args.append("--qlx")
         if len(additional_packs) > 0:

--- a/codeql_bundle/helpers/codeql.py
+++ b/codeql_bundle/helpers/codeql.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from typing import Dict, Any, Iterable, Self, Optional, List
 import yaml
 from dataclasses import dataclass, fields, field
-from enum import Enum
 import logging
 
 logger = logging.getLogger(__name__)
@@ -16,7 +15,7 @@ class CodeQLException(Exception):
 
 
 @dataclass(kw_only=True, frozen=True, eq=True)
-class CodeQLPack:
+class CodeQLPackConfig:
     library: bool = False
     name: str
     version: Version = Version("0.0.0")
@@ -53,25 +52,18 @@ class CodeQLPack:
     def __hash__(self):
         return hash(f"{self.name}@{str(self.version)}")
 
-
-class CodeQLPackKind(Enum):
-    QUERY_PACK = 1
-    LIBRARY_PACK = 2
-    CUSTOMIZATION_PACK = 3
-
-
 @dataclass(kw_only=True, frozen=True, eq=True)
-class ResolvedCodeQLPack(CodeQLPack):
+class CodeQLPack:
     path: Path
-    kind: CodeQLPackKind
+    config: CodeQLPackConfig
 
-    def __hash__(self):
-        return CodeQLPack.__hash__(self)
-
+    def __hash__(self) -> int:
+        return hash(f"{self.path}")
 
 class CodeQL:
     def __init__(self, codeql_path: Path):
         self.codeql_path = codeql_path
+        self._version = None
 
     def _exec(self, command: str, *args: str) -> subprocess.CompletedProcess[str]:
         logger.debug(
@@ -80,16 +72,20 @@ class CodeQL:
         return subprocess.run(
             [f"{self.codeql_path}", command] + [arg for arg in args],
             capture_output=True,
-            text=True,
+            text=True
         )
 
     def version(self) -> Version:
-        cp = self._exec("version", "--format=json")
-        if cp.returncode == 0:
-            version_info = json.loads(cp.stdout)
-            return Version(version_info["version"])
+        if self._version != None:
+            return self._version
         else:
-            raise CodeQLException(f"Failed to run {cp.args} command!")
+            cp = self._exec("version", "--format=json")
+            if cp.returncode == 0:
+                version_info = json.loads(cp.stdout)
+                self._version = Version(version_info["version"])
+                return self._version
+            else:
+                raise CodeQLException(f"Failed to run {cp.args} command!")
 
     def unpacked_location(self) -> Path:
         cp = self._exec("version", "--format=json")
@@ -102,44 +98,36 @@ class CodeQL:
     def supports_qlx(self) -> bool:
         return self.version() >= Version("2.11.4")
 
-    def pack_ls(self, workspace: Path = Path.cwd()) -> List[ResolvedCodeQLPack]:
+    def pack_ls(self, workspace: Path = Path.cwd()) -> List[CodeQLPack]:
         cp = self._exec("pack", "ls", "--format=json", str(workspace))
         if cp.returncode == 0:
             packs: Iterable[Path] = map(Path, json.loads(cp.stdout)["packs"].keys())
 
-            def load(qlpack: Path) -> ResolvedCodeQLPack:
-                with qlpack.open("r") as qlpack_file:
-                    logger.debug(f"Resolving CodeQL pack at {qlpack}.")
-                    qlpack_spec = yaml.safe_load(qlpack_file)
-                    qlpack_spec["path"] = qlpack
-                    if not "library" in qlpack_spec or not qlpack_spec["library"]:
-                        qlpack_spec["kind"] = CodeQLPackKind.QUERY_PACK
-                    else:
-                        if (
-                            qlpack_spec["path"].parent
-                            / qlpack_spec["name"].replace("-", "_")
-                            / "Customizations.qll"
-                        ).exists():
-                            qlpack_spec["kind"] = CodeQLPackKind.CUSTOMIZATION_PACK
-                        else:
-                            qlpack_spec["kind"] = CodeQLPackKind.LIBRARY_PACK
-                    resolved_pack = ResolvedCodeQLPack.from_dict(qlpack_spec)
+            def load(qlpack_yml_path: Path) -> CodeQLPack:
+                with qlpack_yml_path.open("r") as qlpack_yml_file:
+                    logger.debug(f"Loading CodeQL pack configuration at {qlpack_yml_path}.")
+                    qlpack_yml_as_dict: Dict[str, Any] = yaml.safe_load(qlpack_yml_file)
+                    qlpack_config = CodeQLPackConfig.from_dict(qlpack_yml_as_dict)
+                    qlpack = CodeQLPack(path=qlpack_yml_path, config=qlpack_config)
                     logger.debug(
-                        f"Resolved {resolved_pack.name} with version {str(resolved_pack.version)} at {resolved_pack.path} with kind {resolved_pack.kind.name}"
+                        f"Loaded {qlpack.config.name} with version {str(qlpack.config.version)} at {qlpack.path}."
                     )
-                    return resolved_pack
+                    return qlpack
 
-            logger.debug(f"Resolving CodeQL packs for workspace {workspace}")
+            logger.debug(f"Listing CodeQL packs for workspace {workspace}")
             return list(map(load, packs))
         else:
             raise CodeQLException(f"Failed to run {cp.args} command! {cp.stderr}")
 
     def pack_bundle(
         self,
-        pack: ResolvedCodeQLPack,
+        pack: CodeQLPack,
         output_path: Path,
         *additional_packs: Path,
     ):
+        if not pack.config.library:
+            raise CodeQLException(f"Cannot bundle non-library pack {pack.config.name}!")
+
         args = ["bundle", "--format=json", f"--pack-path={output_path}"]
         if len(additional_packs) > 0:
             args.append(f"--additional-packs={':'.join(map(str,additional_packs))}")
@@ -155,10 +143,13 @@ class CodeQL:
 
     def pack_create(
         self,
-        pack: ResolvedCodeQLPack,
+        pack: CodeQLPack,
         output_path: Path,
         *additional_packs: Path,
     ):
+        if pack.config.library:
+            raise CodeQLException(f"Cannot bundle non-query pack {pack.config.name}!")
+
         args = ["create", "--format=json", f"--output={output_path}", "--threads=0"]
         if self.supports_qlx():
             args.append("--qlx")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "codeql-bundle"
-version = "0.1.6"
+version = "0.1.7"
 description = "Tool to create custom CodeQL bundles"
 authors = ["Remco Vermeulen <rvermeulen@users.noreply.github.com>"]
 readme = "README.md"

--- a/tests/workspace-with-cyclic-dep/codeql-workspace.yml
+++ b/tests/workspace-with-cyclic-dep/codeql-workspace.yml
@@ -1,0 +1,2 @@
+provide:
+  - "**/qlpack.yml"

--- a/tests/workspace-with-cyclic-dep/x/qlpack.yml
+++ b/tests/workspace-with-cyclic-dep/x/qlpack.yml
@@ -1,0 +1,7 @@
+---
+library: false
+warnOnImplicitThis: false
+name: cycle/x
+version: 0.0.1
+dependencies:
+  "cycle/y": "*"

--- a/tests/workspace-with-cyclic-dep/y/qlpack.yml
+++ b/tests/workspace-with-cyclic-dep/y/qlpack.yml
@@ -1,0 +1,7 @@
+---
+library: false
+warnOnImplicitThis: false
+name: cycle/y
+version: 0.0.1
+dependencies:
+  "cycle/z": "*"

--- a/tests/workspace-with-cyclic-dep/z/qlpack.yml
+++ b/tests/workspace-with-cyclic-dep/z/qlpack.yml
@@ -1,0 +1,7 @@
+---
+library: false
+warnOnImplicitThis: false
+name: cycle/z
+version: 0.0.1
+dependencies:
+  "cycle/x": "*"

--- a/tests/workspace/codeql-workspace.yml
+++ b/tests/workspace/codeql-workspace.yml
@@ -1,0 +1,2 @@
+provide:
+  - "**/qlpack.yml"

--- a/tests/workspace/cpp/a/codeql-pack.lock.yml
+++ b/tests/workspace/cpp/a/codeql-pack.lock.yml
@@ -1,0 +1,12 @@
+---
+lockVersion: 1.0.0
+dependencies:
+  codeql/cpp-all:
+    version: 0.7.3
+  codeql/ssa:
+    version: 0.0.18
+  codeql/tutorial:
+    version: 0.0.11
+  codeql/util:
+    version: 0.0.11
+compiled: false

--- a/tests/workspace/cpp/a/qlpack.yml
+++ b/tests/workspace/cpp/a/qlpack.yml
@@ -1,0 +1,7 @@
+---
+library: true
+warnOnImplicitThis: false
+name: test/a
+version: 0.0.1
+dependencies:
+  test/aa: "*"

--- a/tests/workspace/cpp/aa/codeql-pack.lock.yml
+++ b/tests/workspace/cpp/aa/codeql-pack.lock.yml
@@ -1,0 +1,12 @@
+---
+lockVersion: 1.0.0
+dependencies:
+  codeql/cpp-all:
+    version: 0.7.3
+  codeql/ssa:
+    version: 0.0.18
+  codeql/tutorial:
+    version: 0.0.11
+  codeql/util:
+    version: 0.0.11
+compiled: false

--- a/tests/workspace/cpp/aa/qlpack.yml
+++ b/tests/workspace/cpp/aa/qlpack.yml
@@ -1,0 +1,7 @@
+---
+library: true
+warnOnImplicitThis: false
+name: test/aa
+version: 0.0.1
+dependencies:
+  "codeql/cpp-all": "0.7.3"

--- a/tests/workspace/cpp/foo-bundle-customizations-tests/FooExternalSourceFunction/Foo.expected
+++ b/tests/workspace/cpp/foo-bundle-customizations-tests/FooExternalSourceFunction/Foo.expected
@@ -1,0 +1,1 @@
+| test.c:4:13:4:15 | call to foo |

--- a/tests/workspace/cpp/foo-bundle-customizations-tests/FooExternalSourceFunction/Foo.ql
+++ b/tests/workspace/cpp/foo-bundle-customizations-tests/FooExternalSourceFunction/Foo.ql
@@ -1,0 +1,4 @@
+import cpp
+import semmle.code.cpp.security.FlowSources
+
+select any(RemoteFlowSource s)

--- a/tests/workspace/cpp/foo-bundle-customizations-tests/FooExternalSourceFunction/test.c
+++ b/tests/workspace/cpp/foo-bundle-customizations-tests/FooExternalSourceFunction/test.c
@@ -1,0 +1,7 @@
+int foo();
+
+int main(int argc, char** argv) {
+    int i = foo();
+
+    return i;
+}

--- a/tests/workspace/cpp/foo-bundle-customizations-tests/codeql-pack.lock.yml
+++ b/tests/workspace/cpp/foo-bundle-customizations-tests/codeql-pack.lock.yml
@@ -1,0 +1,12 @@
+---
+lockVersion: 1.0.0
+dependencies:
+  codeql/cpp-all:
+    version: 0.7.3
+  codeql/ssa:
+    version: 0.0.18
+  codeql/tutorial:
+    version: 0.0.11
+  codeql/util:
+    version: 0.0.11
+compiled: false

--- a/tests/workspace/cpp/foo-bundle-customizations-tests/qlpack.yml
+++ b/tests/workspace/cpp/foo-bundle-customizations-tests/qlpack.yml
@@ -1,0 +1,6 @@
+library: true
+name: foo/bundle-customizations-tests
+version: 0.0.1
+dependencies:
+  "test/a": "*"
+extractor: cpp

--- a/tests/workspace/cpp/foo-customization-tests/FooExternalSourceFunction/Foo.expected
+++ b/tests/workspace/cpp/foo-customization-tests/FooExternalSourceFunction/Foo.expected
@@ -1,0 +1,1 @@
+| test.c:4:13:4:15 | call to foo |

--- a/tests/workspace/cpp/foo-customization-tests/FooExternalSourceFunction/Foo.ql
+++ b/tests/workspace/cpp/foo-customization-tests/FooExternalSourceFunction/Foo.ql
@@ -1,0 +1,5 @@
+import cpp
+import foo.cpp_customizations.Customizations
+import semmle.code.cpp.security.FlowSources
+
+select any(RemoteFlowSource s)

--- a/tests/workspace/cpp/foo-customization-tests/FooExternalSourceFunction/test.c
+++ b/tests/workspace/cpp/foo-customization-tests/FooExternalSourceFunction/test.c
@@ -1,0 +1,7 @@
+int foo();
+
+int main(int argc, char** argv) {
+    int i = foo();
+
+    return i;
+}

--- a/tests/workspace/cpp/foo-customization-tests/codeql-pack.lock.yml
+++ b/tests/workspace/cpp/foo-customization-tests/codeql-pack.lock.yml
@@ -1,0 +1,12 @@
+---
+lockVersion: 1.0.0
+dependencies:
+  codeql/cpp-all:
+    version: 0.7.3
+  codeql/ssa:
+    version: 0.0.18
+  codeql/tutorial:
+    version: 0.0.11
+  codeql/util:
+    version: 0.0.11
+compiled: false

--- a/tests/workspace/cpp/foo-customization-tests/qlpack.yml
+++ b/tests/workspace/cpp/foo-customization-tests/qlpack.yml
@@ -1,0 +1,7 @@
+library: true
+name: foo/cpp-customizations-tests
+version: 0.0.1
+dependencies:
+  "foo/cpp-customizations": "*"
+  "test/a": "*"
+extractor: cpp

--- a/tests/workspace/cpp/foo-customizations/codeql-pack.lock.yml
+++ b/tests/workspace/cpp/foo-customizations/codeql-pack.lock.yml
@@ -1,0 +1,12 @@
+---
+lockVersion: 1.0.0
+dependencies:
+  codeql/cpp-all:
+    version: 0.7.3
+  codeql/ssa:
+    version: 0.0.18
+  codeql/tutorial:
+    version: 0.0.11
+  codeql/util:
+    version: 0.0.11
+compiled: false

--- a/tests/workspace/cpp/foo-customizations/foo/cpp_customizations/Customizations.qll
+++ b/tests/workspace/cpp/foo-customizations/foo/cpp_customizations/Customizations.qll
@@ -1,0 +1,13 @@
+import cpp
+private import semmle.code.cpp.security.FlowSources
+
+module FooSources {
+  private class FooExternalSourceFunction extends RemoteFlowSourceFunction {
+    FooExternalSourceFunction() { this.hasName("foo") }
+
+    override predicate hasRemoteFlowSource(FunctionOutput output, string description) {
+      output.isReturnValue() and
+      description = "value returned by " + this.getName()
+    }
+  }
+}

--- a/tests/workspace/cpp/foo-customizations/qlpack.yml
+++ b/tests/workspace/cpp/foo-customizations/qlpack.yml
@@ -1,0 +1,5 @@
+library: True
+name: foo/cpp-customizations
+version: 0.0.1
+dependencies:
+  "codeql/cpp-all": "0.7.3"


### PR DESCRIPTION
The order in which packs are bundled didn't consider dependencies between packs. This could lead to failures when a bundle being added to the bundle couldn't resolve its dependencies from the bundle because they weren't added yet.

This fix introduces a dependency graph that orders the workspace packs and impacted bundle packs. 