### PR TITLE
Ensure non-customization library packs can be bundled

### DIFF
--- a/codeql_bundle/helpers/bundle.py
+++ b/codeql_bundle/helpers/bundle.py
@@ -566,8 +566,11 @@ class CustomBundle(Bundle):
 
         def bundle_library_pack(library_pack: ResolvedCodeQLPack):
             logging.info(f"Bundling the library pack {library_pack.config.name}.")
+
+            pack_copy = copy_pack(library_pack)
+
             self.codeql.pack_bundle(
-                library_pack,
+                pack_copy,
                 self.bundle_path / "qlpacks",
                 disable_precompilation=self.disable_precompilation,
             )


### PR DESCRIPTION
For workspaces with a mix of customization and non-customization library packs, bundling fails when trying to copy over the non-customization library packs with something similar to this error:

```
ERROR: Pack 'my-js-customization-pack' has a cyclic dependency on pack 'codeql/javascript-all'.
A fatal error occurred: A 'codeql resolve extensions-by-pack' operation failed with error code 2
```

The reason for this is because:
 * In the original workspace (containing the custom packs), the customization packs depend on the standard library pack.
 * When we copy the customization packs over, we invert the dependency - so that in the output bundle, the standard library pack depend on the customization packs for that language.
    * We implement this by copying each of the customization and standard library packs to a temp directory to modify the dependencies before packing them into the output bundle.
 * Library packs that are not customization packs are not copied into a temporary directory (because they don't require a modification of dependencies.
 * However, this means that the CodeQL CLI will validate the original workspace as a whole, but against the output bundle. This leads it to discovering the original customization packs, but trying to match them with the standard library packs in the output bundle. This creates a circular dependency.

We solve this by also copying non-customization library packs to a temporary directory, which then prevents the CodeQL CLI from scanning the original workspace and erroneously reporting a circular dependency.