### PR TITLE
RAM override argument pass-through to CodeQL CLI

### DIFF
--- a/codeql_bundle/cli.py
+++ b/codeql_bundle/cli.py
@@ -75,7 +75,7 @@ logger = logging.getLogger(__name__)
 @click.option(
     "-M",
     "--ram",
-    type=click.Int,
+    type=click.INT,
     help="Set total amount of RAM that the compiler should be allowed to use.",
 )
 @click.argument("packs", nargs=-1, required=True)

--- a/codeql_bundle/cli.py
+++ b/codeql_bundle/cli.py
@@ -72,6 +72,12 @@ logger = logging.getLogger(__name__)
     type=click.Path(exists=True, path_type=Path),
     help="Path to a JSON file specifying additional data to install into the bundle",
 )
+@click.option(
+    "-M",
+    "--ram",
+    type=click.Int,
+    help="Set total amount of RAM that the compiler should be allowed to use.",
+)
 @click.argument("packs", nargs=-1, required=True)
 def main(
     bundle_path: Path,
@@ -82,6 +88,7 @@ def main(
     platform: List[str],
     code_scanning_config: Optional[Path],
     additional_data_config: Optional[Path],
+    ram: Optional[int],
     packs: List[str],
 ) -> None:
 
@@ -109,6 +116,7 @@ def main(
         bundle = CustomBundle(bundle_path, workspace)
         # options for custom bundle
         bundle.disable_precompilation = no_precompile
+        bundle.ram = ram
 
         unsupported_platforms = list(
             filter(

--- a/codeql_bundle/helpers/bundle.py
+++ b/codeql_bundle/helpers/bundle.py
@@ -278,6 +278,15 @@ class Bundle:
     def disable_precompilation(self, value: bool):
         self._disable_precompilation = value
 
+    @property
+    def ram(self):
+        return self.codeql.ram
+
+    @ram.setter
+    def ram(self, value: int):
+        self.codeql.ram = value
+
+
 
 class CustomBundle(Bundle):
     def __init__(self, bundle_path: Path, workspace_path: Path = Path.cwd()) -> None:

--- a/codeql_bundle/helpers/codeql.py
+++ b/codeql_bundle/helpers/codeql.py
@@ -157,6 +157,7 @@ class CodeQL:
             args.append(f"--additional-packs={':'.join(map(str,additional_packs))}")
 
         if self.ram is not None:
+            logging.info(f"Using {self.ram} MB of RAM for packing {pack.config.name}.")
             args.append(f"--ram={self.ram}")
 
         cp = self._exec(
@@ -191,6 +192,7 @@ class CodeQL:
         if len(additional_packs) > 0:
             args.append(f"--additional-packs={':'.join(map(str,additional_packs))}")
         if self.ram is not None:
+            logging.info(f"Using {self.ram} MB of RAM for packing {pack.config.name}.")
             args.append(f"--ram={self.ram}")
         cp = self._exec(
             "pack",

--- a/codeql_bundle/helpers/codeql.py
+++ b/codeql_bundle/helpers/codeql.py
@@ -146,7 +146,7 @@ class CodeQL:
         if not pack.config.library:
             raise CodeQLException(f"Cannot bundle non-library pack {pack.config.name}!")
 
-        args = ["bundle", "--format=json", f"--pack-path={output_path}"]
+        args = ["bundle", "--format=json", f"--pack-path={output_path}", "--threads=0"]
         if disable_precompilation:
             args.append("--no-precompile")
             logging.warn(
@@ -157,7 +157,7 @@ class CodeQL:
             args.append(f"--additional-packs={':'.join(map(str,additional_packs))}")
 
         if self.ram is not None:
-            logging.info(f"Using {self.ram} MB of RAM for packing {pack.config.name}.")
+            logging.info(f"Using {self.ram} MB of RAM for bundling {pack.config.name}.")
             args.append(f"--ram={self.ram}")
 
         cp = self._exec(

--- a/codeql_bundle/helpers/codeql.py
+++ b/codeql_bundle/helpers/codeql.py
@@ -64,6 +64,7 @@ class CodeQL:
     def __init__(self, codeql_path: Path):
         self.codeql_path = codeql_path
         self._version = None
+        self._ram = None
 
     @property
     def disable_precompilation(self):
@@ -72,6 +73,14 @@ class CodeQL:
     @disable_precompilation.setter
     def disable_precompilation(self, value: bool):
         self._disable_precompilation = value
+
+    @property
+    def ram(self):
+        return self._ram
+
+    @ram.setter
+    def ram(self, value: int):
+        self._ram = value
 
     def _exec(self, command: str, *args: str) -> subprocess.CompletedProcess[str]:
         logger.debug(
@@ -84,7 +93,7 @@ class CodeQL:
         )
 
     def version(self) -> Version:
-        if self._version != None:
+        if self._version is not None:
             return self._version
         else:
             cp = self._exec("version", "--format=json")
@@ -146,6 +155,10 @@ class CodeQL:
 
         if len(additional_packs) > 0:
             args.append(f"--additional-packs={':'.join(map(str,additional_packs))}")
+
+        if self.ram is not None:
+            args.append(f"--ram={self.ram}")
+
         cp = self._exec(
             "pack",
             *args,
@@ -177,6 +190,8 @@ class CodeQL:
             args.append("--qlx")
         if len(additional_packs) > 0:
             args.append(f"--additional-packs={':'.join(map(str,additional_packs))}")
+        if self.ram is not None:
+            args.append(f"--ram={self.ram}")
         cp = self._exec(
             "pack",
             *args,


### PR DESCRIPTION
Add support to the codeql-bundle tool for overriding the amount of RAM used by the codeql CLI `bundle` commands.

- The CodeQL CLI `bundle` commands accept the `-M`/`--ram` arguments to override the amount of heap space used when packaging bundles.
- This change allows the codeql-bundle tool to pass-through an override amount to the underlying codeql cli `bundle` commands
- Also ensure the same threads arg is used when bundling a pack as the number of threads used when creating a pack