### PR TITLE
Add feature to respect threads option on pack create step

### DIFF
--- a/codeql_bundle/cli.py
+++ b/codeql_bundle/cli.py
@@ -72,6 +72,13 @@ logger = logging.getLogger(__name__)
     type=click.Path(exists=True, path_type=Path),
     help="Path to a JSON file specifying additional data to install into the bundle",
 )
+@click.option(
+    "-j",
+    "--threads",
+    type=click.INT,
+    help="Use this many threads to compile queries.",
+)
+
 @click.argument("packs", nargs=-1, required=True)
 def main(
     bundle_path: Path,
@@ -82,6 +89,7 @@ def main(
     platform: List[str],
     code_scanning_config: Optional[Path],
     additional_data_config: Optional[Path],
+    threads: Optional[int],
     packs: List[str],
 ) -> None:
 
@@ -109,6 +117,7 @@ def main(
         bundle = CustomBundle(bundle_path, workspace)
         # options for custom bundle
         bundle.disable_precompilation = no_precompile
+        bundle.threads = threads
 
         unsupported_platforms = list(
             filter(

--- a/codeql_bundle/helpers/bundle.py
+++ b/codeql_bundle/helpers/bundle.py
@@ -278,6 +278,13 @@ class Bundle:
     def disable_precompilation(self, value: bool):
         self._disable_precompilation = value
 
+    @property
+    def threads(self):
+        return self.codeql.threads
+
+    @threads.setter
+    def threads(self, value: int):
+        self.codeql.threads= value
 
 class CustomBundle(Bundle):
     def __init__(self, bundle_path: Path, workspace_path: Path = Path.cwd()) -> None:

--- a/codeql_bundle/helpers/codeql.py
+++ b/codeql_bundle/helpers/codeql.py
@@ -64,6 +64,7 @@ class CodeQL:
     def __init__(self, codeql_path: Path):
         self.codeql_path = codeql_path
         self._version = None
+        self._threads = None
 
     @property
     def disable_precompilation(self):
@@ -72,6 +73,14 @@ class CodeQL:
     @disable_precompilation.setter
     def disable_precompilation(self, value: bool):
         self._disable_precompilation = value
+    
+    @property
+    def threads(self):
+        return self._threads
+
+    @threads.setter
+    def threads(self, value: int):
+        self._threads = value
 
     def _exec(self, command: str, *args: str) -> subprocess.CompletedProcess[str]:
         logger.debug(
@@ -166,7 +175,14 @@ class CodeQL:
         if pack.config.library:
             raise CodeQLException(f"Cannot bundle non-query pack {pack.config.name}!")
 
-        args = ["create", "--format=json", f"--output={output_path}", "--threads=0", "--no-default-compilation-cache"]
+        args = ["create", "--format=json", f"--output={output_path}", "--no-default-compilation-cache"]
+
+        if self.threads is not None:
+            logging.info(f"Using {self.threads} threads for bundling {pack.config.name}.")
+            args.append(f"--threads={self.threads}")
+        else:
+            args.append(f"--threads=0")
+            
         if disable_precompilation:
             args.append("--no-precompile")
             logging.warn(


### PR DESCRIPTION
very similar to https://github.com/advanced-security/codeql-bundle/pull/19 
but just for threads on the pack create step
for users who want an option to control number of threads used on specifically that step

# Context:

## problem

currently the custom bundler tool has no way to allow the user to adjust the threads that the CodeQL CLI uses at any point in the bundle creation process. It is hardcoded to use `threads=0` which means max threads. For some systems this is suspected to cause out of memory errors when doing custom bundle creation - where the CLI allocates "too much" memory and then fails to create the custom bundle. 

## solution
Giving the user the option to control the number of threads can allow for a better control over the underlying CLI behaviour. If no threads are provided to the bundler, it will now still default to `threads=0`. Otherwise the threads arg provided to the bundler will simply be forwarded to the CLI command (within) the bundler `codeql pack create` where most of the potential compilation may be triggered.

## testing

this can be tested via:
```
poetry run python3.11 codeql_bundle/cli.py  --bundle <path-to-OOTB-bundle> --output <path-to-custom-bundle> --workspace <path-to-codeql-workspace.yml> --log DEBUG --threads 2 <PACK-NAMES>
```

## future steps

This solution may not cover all cases where out of memory conditions are created by the custom bundler. merging this PR is required for further testing in such environments.