### PR TITLE
Fix cache workflow environment context

### DIFF
--- a/.github/workflows/codeql-compilation-caches.yml
+++ b/.github/workflows/codeql-compilation-caches.yml
@@ -33,7 +33,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  CODEQL_BUNDLE_CACHE_DIR: ${{ runner.temp }}/codeql-bundle-cache
+  CODEQL_BUNDLE_CACHE_DIR: ${{ github.workspace }}/.codeql-bundle-cache
   PIP_DISABLE_PIP_VERSION_CHECK: "1"
 
 jobs:


### PR DESCRIPTION
The cache workflow failed before creating any jobs because the global `env` block referenced `runner.temp`, where the `runner` context is unavailable.

Use `github.workspace` for the persisted cache directory instead. The workflow now passes Actionlint validation.